### PR TITLE
For historical builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ENV ETEBASE_PORT ${PORT}
 # Unfortunately this needs a compiler, so we install one for just this step. We also install
 # libpcre3 to enable internal routing in uWSGI.
 RUN apt-get update \
- && apt-get install -y build-essential python3-dev libpcre3-dev \
+ && apt-get install -y mime-support build-essential python3-dev libpcre3-dev \
  && pip3 install uwsgi \
  && pip3 cache purge \
  && apt-get purge -y --auto-remove build-essential python3-dev libpcre3-dev \

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -39,7 +39,7 @@ ENV ETEBASE_PORT ${PORT}
 # Unfortunately this needs a compiler, so we install one for just this step. We also install
 # libpcre3 to enable internal routing in uWSGI.
 RUN apt-get update \
- && apt-get install -y build-essential python3-dev libpcre3-dev \
+ && apt-get install -y mime-support build-essential python3-dev libpcre3-dev \
  && pip3 install uwsgi \
  && pip3 cache purge \
  && apt-get purge -y --auto-remove build-essential python3-dev libpcre3-dev \

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,5 +1,5 @@
-ARG ETEBASE_TAG=057b908565072bf9b1003410c0080f42294d446a
-ARG ETESYNC_WEB_TAG=c0d884afd7499d3174b405bb10a2629eec376ecc
+ARG `ETEBASE_TAG'=ETEBASE_TAG
+ARG `ETESYNC_WEB_TAG'=ETESYNC_WEB_TAG
 
 ARG PUID=1000
 ARG PGID=1000
@@ -10,9 +10,9 @@ ARG PORT=8080
 
 FROM node:12 as web
 
-ARG ETESYNC_WEB_TAG
+ARG `ETESYNC_WEB_TAG'
 
-ADD https://github.com/etesync/etesync-web/archive/${ETESYNC_WEB_TAG}.tar.gz etesync_web.tar.gz
+ADD https://github.com/etesync/etesync-web/archive/${`ETESYNC_WEB_TAG'}.tar.gz etesync_web.tar.gz
 ENV REACT_APP_DEFAULT_API_PATH "/"
 RUN mkdir -p etesync-web \
  && tar xf etesync_web.tar.gz --strip-components=1 -C etesync-web \
@@ -24,7 +24,7 @@ RUN mkdir -p etesync-web \
 
 FROM python:3.8-slim
 
-ARG ETEBASE_TAG
+ARG `ETEBASE_TAG'
 ARG PUID
 ARG PGID
 ARG PORT
@@ -46,7 +46,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Download Etebase.
-ADD https://github.com/etesync/server/archive/${ETEBASE_TAG}.tar.gz etebase.tar.gz
+ADD https://github.com/etesync/server/archive/${`ETEBASE_TAG'}.tar.gz etebase.tar.gz
 RUN mkdir -p ${ETEBASE_DIRECTORY} \
  && tar xf etebase.tar.gz --strip-components=1 --exclude="example-configs" -C ${ETEBASE_DIRECTORY} \
  && rm etebase.tar.gz \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+include Makefile.m4
+
+ETEBASE_TAG="$(shell git ls-remote https://github.com/etesync/server.git refs/heads/master|cut -f1)"
+ETESYNC_WEB_TAG="$(shell git ls-remote https://github.com/etesync/etesync-web.git refs/heads/master|cut -f1)"
+
+M4SCRIPT += -DETEBASE_TAG=$(ETEBASE_TAG)
+M4SCRIPT += -DETESYNC_WEB_TAG=$(ETESYNC_WEB_TAG)
+
+Dockerfile-force: Dockerfile-force-impl Dockerfile
+
+Dockerfile-force-impl:
+	touch Dockerfile.in
+
+Dockerfile: Dockerfile.in
+
+build: Dockerfile
+	docker build .
+
+all: Dockerfile-force build
+
+.PHONY: all build Dockerfile-force Dockerfile-force-impl

--- a/Makefile.m4
+++ b/Makefile.m4
@@ -1,0 +1,8 @@
+.SUFFIXES: .in       # Add .in as a suffix
+
+M4       = m4
+M4FLAGS  =
+M4SCRIPT =
+
+.in:
+	${M4} ${M4FLAGS} ${M4SCRIPT} $< > $*


### PR DESCRIPTION
This provides a number of useful features:
1. Upgrading dependencies is set as action dependant(this can be automated)
2. Historical instances continue to build and work months or perhaps years out
    * Unlike today where newly discovered bugs could be introduced just because it's months after the commit was made
3. Better identification of bugs in the upstream sources
    * Think of the effect this has on bisect